### PR TITLE
Modify swap constraints, add swap guardian.

### DIFF
--- a/token-swap/program/src/constraints.rs
+++ b/token-swap/program/src/constraints.rs
@@ -65,11 +65,11 @@ const OWNER_KEY: &str = env!("SWAP_PROGRAM_OWNER_FEE_ADDRESS");
 const FEES: &Fees = &Fees {
     trade_fee_numerator: 0,
     trade_fee_denominator: 10000,
-    owner_trade_fee_numerator: 5,
+    owner_trade_fee_numerator: 0,
     owner_trade_fee_denominator: 10000,
     owner_withdraw_fee_numerator: 0,
     owner_withdraw_fee_denominator: 0,
-    host_fee_numerator: 20,
+    host_fee_numerator: 0,
     host_fee_denominator: 100,
 };
 #[cfg(feature = "production")]

--- a/token-swap/program/src/error.rs
+++ b/token-swap/program/src/error.rs
@@ -102,6 +102,12 @@ pub enum SwapError {
     /// The operation cannot be performed on the given curve
     #[error("The operation cannot be performed on the given curve")]
     UnsupportedCurveOperation,
+    /// Incorrect swap guardian was provided with the operation.
+    #[error("The provided swap guardian is incorrect")]
+    WrongSwapGuardian,
+    /// The swap guardian is not a signer.
+    #[error("No swap guardian signature")]
+    NoSwapGuardianSig
 }
 impl From<SwapError> for ProgramError {
     fn from(e: SwapError) -> Self {

--- a/token-swap/program/src/error.rs
+++ b/token-swap/program/src/error.rs
@@ -104,10 +104,10 @@ pub enum SwapError {
     UnsupportedCurveOperation,
     /// Incorrect swap guardian was provided with the operation.
     #[error("The provided swap guardian is incorrect")]
-    WrongSwapGuardian,
+    IncorrectSwapGuardian,
     /// The swap guardian is not a signer.
     #[error("No swap guardian signature")]
-    NoSwapGuardianSig
+    NoSwapGuardianSignature
 }
 impl From<SwapError> for ProgramError {
     fn from(e: SwapError) -> Self {

--- a/token-swap/program/src/error.rs
+++ b/token-swap/program/src/error.rs
@@ -107,7 +107,7 @@ pub enum SwapError {
     IncorrectSwapGuardian,
     /// The swap guardian is not a signer.
     #[error("No swap guardian signature")]
-    NoSwapGuardianSignature
+    NoSwapGuardianSignature,
 }
 impl From<SwapError> for ProgramError {
     fn from(e: SwapError) -> Self {

--- a/token-swap/program/src/instruction.rs
+++ b/token-swap/program/src/instruction.rs
@@ -362,7 +362,7 @@ pub fn initialize(
     destination_pubkey: &Pubkey,
     fees: Fees,
     swap_curve: SwapCurve,
-    swap_guardian: &Pubkey
+    swap_guardian: &Pubkey,
 ) -> Result<Instruction, ProgramError> {
     let init_data = SwapInstruction::Initialize(Initialize { fees, swap_curve });
     let data = init_data.pack();
@@ -376,7 +376,7 @@ pub fn initialize(
         AccountMeta::new_readonly(*fee_pubkey, false),
         AccountMeta::new(*destination_pubkey, false),
         AccountMeta::new_readonly(*token_program_id, false),
-        AccountMeta::new_readonly(*swap_guardian, false)
+        AccountMeta::new_readonly(*swap_guardian, false),
     ];
 
     Ok(Instruction {
@@ -400,7 +400,7 @@ pub fn deposit_all_token_types(
     pool_mint_pubkey: &Pubkey,
     destination_pubkey: &Pubkey,
     instruction: DepositAllTokenTypes,
-    swap_guardian: &Pubkey
+    swap_guardian: &Pubkey,
 ) -> Result<Instruction, ProgramError> {
     let data = SwapInstruction::DepositAllTokenTypes(instruction).pack();
 
@@ -415,7 +415,7 @@ pub fn deposit_all_token_types(
         AccountMeta::new(*pool_mint_pubkey, false),
         AccountMeta::new(*destination_pubkey, false),
         AccountMeta::new_readonly(*token_program_id, false),
-        AccountMeta::new_readonly(*swap_guardian, true)
+        AccountMeta::new_readonly(*swap_guardian, true),
     ];
 
     Ok(Instruction {
@@ -440,7 +440,7 @@ pub fn withdraw_all_token_types(
     destination_token_a_pubkey: &Pubkey,
     destination_token_b_pubkey: &Pubkey,
     instruction: WithdrawAllTokenTypes,
-    swap_guardian: &Pubkey
+    swap_guardian: &Pubkey,
 ) -> Result<Instruction, ProgramError> {
     let data = SwapInstruction::WithdrawAllTokenTypes(instruction).pack();
 
@@ -456,7 +456,7 @@ pub fn withdraw_all_token_types(
         AccountMeta::new(*destination_token_b_pubkey, false),
         AccountMeta::new(*fee_account_pubkey, false),
         AccountMeta::new_readonly(*token_program_id, false),
-        AccountMeta::new_readonly(*swap_guardian, true)
+        AccountMeta::new_readonly(*swap_guardian, true),
     ];
 
     Ok(Instruction {
@@ -479,7 +479,7 @@ pub fn deposit_single_token_type_exact_amount_in(
     pool_mint_pubkey: &Pubkey,
     destination_pubkey: &Pubkey,
     instruction: DepositSingleTokenTypeExactAmountIn,
-    swap_guardian: &Pubkey
+    swap_guardian: &Pubkey,
 ) -> Result<Instruction, ProgramError> {
     let data = SwapInstruction::DepositSingleTokenTypeExactAmountIn(instruction).pack();
 
@@ -493,7 +493,7 @@ pub fn deposit_single_token_type_exact_amount_in(
         AccountMeta::new(*pool_mint_pubkey, false),
         AccountMeta::new(*destination_pubkey, false),
         AccountMeta::new_readonly(*token_program_id, false),
-        AccountMeta::new_readonly(*swap_guardian, true)
+        AccountMeta::new_readonly(*swap_guardian, true),
     ];
 
     Ok(Instruction {
@@ -517,7 +517,7 @@ pub fn withdraw_single_token_type_exact_amount_out(
     swap_token_b_pubkey: &Pubkey,
     destination_pubkey: &Pubkey,
     instruction: WithdrawSingleTokenTypeExactAmountOut,
-    swap_guardian: &Pubkey
+    swap_guardian: &Pubkey,
 ) -> Result<Instruction, ProgramError> {
     let data = SwapInstruction::WithdrawSingleTokenTypeExactAmountOut(instruction).pack();
 
@@ -532,7 +532,7 @@ pub fn withdraw_single_token_type_exact_amount_out(
         AccountMeta::new(*destination_pubkey, false),
         AccountMeta::new(*fee_account_pubkey, false),
         AccountMeta::new_readonly(*token_program_id, false),
-        AccountMeta::new_readonly(*swap_guardian, true)
+        AccountMeta::new_readonly(*swap_guardian, true),
     ];
 
     Ok(Instruction {
@@ -557,7 +557,7 @@ pub fn swap(
     pool_fee_pubkey: &Pubkey,
     host_fee_pubkey: Option<&Pubkey>,
     instruction: Swap,
-    swap_guardian: &Pubkey
+    swap_guardian: &Pubkey,
 ) -> Result<Instruction, ProgramError> {
     let data = SwapInstruction::Swap(instruction).pack();
 

--- a/token-swap/program/src/instruction.rs
+++ b/token-swap/program/src/instruction.rs
@@ -97,15 +97,19 @@ pub enum SwapInstruction {
     ///   Initializes a new swap
     ///
     ///   0. `[writable, signer]` New Token-swap to create.
-    ///   1. `[]` swap authority derived from `create_program_address(&[Token-swap account])`
+    ///   1. `[]` swap authority derived from
+    ///      `create_program_address(&[Token-swap account])`
     ///   2. `[]` token_a Account. Must be non zero, owned by swap authority.
     ///   3. `[]` token_b Account. Must be non zero, owned by swap authority.
-    ///   4. `[writable]` Pool Token Mint. Must be empty, owned by swap authority.
-    ///   5. `[]` Pool Token Account to deposit trading and withdraw fees.
-    ///   Must be empty, not owned by swap authority
+    ///   4. `[writable]` Pool Token Mint. Must be empty, owned by swap
+    ///      authority.
+    ///   5. `[]` Pool Token Account to deposit trading and withdraw fees. Must
+    ///   be empty, not owned by swap authority
     ///   6. `[writable]` Pool Token Account to deposit the initial pool token
     ///   supply.  Must be empty, not owned by swap authority.
     ///   7. `[]` Token program id
+    ///   8. `[]` Account that gates swap actions. Must sign for the swap to be
+    ///      used.
     Initialize(Initialize),
 
     ///   Swap the tokens in the pool.
@@ -113,19 +117,23 @@ pub enum SwapInstruction {
     ///   0. `[]` Token-swap
     ///   1. `[]` swap authority
     ///   2. `[]` user transfer authority
-    ///   3. `[writable]` token_(A|B) SOURCE Account, amount is transferable by user transfer authority,
-    ///   4. `[writable]` token_(A|B) Base Account to swap INTO.  Must be the SOURCE token.
-    ///   5. `[writable]` token_(A|B) Base Account to swap FROM.  Must be the DESTINATION token.
-    ///   6. `[writable]` token_(A|B) DESTINATION Account assigned to USER as the owner.
+    ///   3. `[writable]` token_(A|B) SOURCE Account, amount is transferable by
+    ///   user transfer authority, 4. `[writable]` token_(A|B) Base Account to
+    ///   swap INTO.  Must be the SOURCE token. 5. `[writable]` token_(A|B) Base
+    ///   Account to swap FROM.  Must be the DESTINATION token. 6. `[writable]`
+    ///   token_(A|B) DESTINATION Account assigned to USER as the owner.
     ///   7. `[writable]` Pool token mint, to generate trading fees
     ///   8. `[writable]` Fee account, to receive trading fees
     ///   9. `[]` Token program id
-    ///   10. `[optional, writable]` Host fee account to receive additional trading fees
+    ///  10. `[signer]` Account that gates swap actions. Must sign for the swap
+    ///      to be used.
+    ///  11. `[optional, writable]` Host fee account to receive additional
+    ///       trading fees.
     Swap(Swap),
 
     ///   Deposit both types of tokens into the pool.  The output is a "pool"
-    ///   token representing ownership in the pool. Inputs are converted to
-    ///   the current ratio.
+    ///   token representing ownership in the pool. Inputs are converted to the
+    ///   current ratio.
     ///
     ///   0. `[]` Token-swap
     ///   1. `[]` swap authority
@@ -135,8 +143,11 @@ pub enum SwapInstruction {
     ///   5. `[writable]` token_a Base Account to deposit into.
     ///   6. `[writable]` token_b Base Account to deposit into.
     ///   7. `[writable]` Pool MINT account, swap authority is the owner.
-    ///   8. `[writable]` Pool Account to deposit the generated tokens, user is the owner.
+    ///   8. `[writable]` Pool Account to deposit the generated tokens, user is
+    ///      the owner.
     ///   9. `[]` Token program id
+    ///  10. `[signer]` Account that gates swap actions. Must sign for the swap
+    ///      to be used.
     DepositAllTokenTypes(DepositAllTokenTypes),
 
     ///   Withdraw both types of tokens from the pool at the current ratio, given
@@ -147,13 +158,16 @@ pub enum SwapInstruction {
     ///   1. `[]` swap authority
     ///   2. `[]` user transfer authority
     ///   3. `[writable]` Pool mint account, swap authority is the owner
-    ///   4. `[writable]` SOURCE Pool account, amount is transferable by user transfer authority.
+    ///   4. `[writable]` SOURCE Pool account, amount is transferable by user
+    ///      transfer authority.
     ///   5. `[writable]` token_a Swap Account to withdraw FROM.
     ///   6. `[writable]` token_b Swap Account to withdraw FROM.
     ///   7. `[writable]` token_a user Account to credit.
     ///   8. `[writable]` token_b user Account to credit.
     ///   9. `[writable]` Fee account, to receive withdrawal fees
     ///   10. `[]` Token program id
+    ///   11. `[signer]` Account that gates swap actions. Must sign for the swap
+    ///      to be used.
     WithdrawAllTokenTypes(WithdrawAllTokenTypes),
 
     ///   Deposit one type of tokens into the pool.  The output is a "pool" token
@@ -163,12 +177,16 @@ pub enum SwapInstruction {
     ///   0. `[]` Token-swap
     ///   1. `[]` swap authority
     ///   2. `[]` user transfer authority
-    ///   3. `[writable]` token_(A|B) SOURCE Account, amount is transferable by user transfer authority,
+    ///   3. `[writable]` token_(A|B) SOURCE Account, amount is transferable by
+    ///      user transfer authority,
     ///   4. `[writable]` token_a Swap Account, may deposit INTO.
     ///   5. `[writable]` token_b Swap Account, may deposit INTO.
     ///   6. `[writable]` Pool MINT account, swap authority is the owner.
-    ///   7. `[writable]` Pool Account to deposit the generated tokens, user is the owner.
+    ///   7. `[writable]` Pool Account to deposit the generated tokens, user is
+    ///      the owner.
     ///   8. `[]` Token program id
+    ///   9. `[signer]` Account that gates swap actions. Must sign for the swap
+    ///      to be used.
     DepositSingleTokenTypeExactAmountIn(DepositSingleTokenTypeExactAmountIn),
 
     ///   Withdraw one token type from the pool at the current ratio given the
@@ -178,12 +196,15 @@ pub enum SwapInstruction {
     ///   1. `[]` swap authority
     ///   2. `[]` user transfer authority
     ///   3. `[writable]` Pool mint account, swap authority is the owner
-    ///   4. `[writable]` SOURCE Pool account, amount is transferable by user transfer authority.
+    ///   4. `[writable]` SOURCE Pool account, amount is transferable by user
+    ///      transfer authority.
     ///   5. `[writable]` token_a Swap Account to potentially withdraw from.
     ///   6. `[writable]` token_b Swap Account to potentially withdraw from.
     ///   7. `[writable]` token_(A|B) User Account to credit
     ///   8. `[writable]` Fee account, to receive withdrawal fees
     ///   9. `[]` Token program id
+    ///  10. `[signer]` Account that gates swap actions. Must sign for the swap
+    ///      to be used.
     WithdrawSingleTokenTypeExactAmountOut(WithdrawSingleTokenTypeExactAmountOut),
 }
 
@@ -341,6 +362,7 @@ pub fn initialize(
     destination_pubkey: &Pubkey,
     fees: Fees,
     swap_curve: SwapCurve,
+    swap_guardian: &Pubkey
 ) -> Result<Instruction, ProgramError> {
     let init_data = SwapInstruction::Initialize(Initialize { fees, swap_curve });
     let data = init_data.pack();
@@ -354,6 +376,7 @@ pub fn initialize(
         AccountMeta::new_readonly(*fee_pubkey, false),
         AccountMeta::new(*destination_pubkey, false),
         AccountMeta::new_readonly(*token_program_id, false),
+        AccountMeta::new_readonly(*swap_guardian, false)
     ];
 
     Ok(Instruction {
@@ -377,6 +400,7 @@ pub fn deposit_all_token_types(
     pool_mint_pubkey: &Pubkey,
     destination_pubkey: &Pubkey,
     instruction: DepositAllTokenTypes,
+    swap_guardian: &Pubkey
 ) -> Result<Instruction, ProgramError> {
     let data = SwapInstruction::DepositAllTokenTypes(instruction).pack();
 
@@ -391,6 +415,7 @@ pub fn deposit_all_token_types(
         AccountMeta::new(*pool_mint_pubkey, false),
         AccountMeta::new(*destination_pubkey, false),
         AccountMeta::new_readonly(*token_program_id, false),
+        AccountMeta::new_readonly(*swap_guardian, true)
     ];
 
     Ok(Instruction {
@@ -415,6 +440,7 @@ pub fn withdraw_all_token_types(
     destination_token_a_pubkey: &Pubkey,
     destination_token_b_pubkey: &Pubkey,
     instruction: WithdrawAllTokenTypes,
+    swap_guardian: &Pubkey
 ) -> Result<Instruction, ProgramError> {
     let data = SwapInstruction::WithdrawAllTokenTypes(instruction).pack();
 
@@ -430,6 +456,7 @@ pub fn withdraw_all_token_types(
         AccountMeta::new(*destination_token_b_pubkey, false),
         AccountMeta::new(*fee_account_pubkey, false),
         AccountMeta::new_readonly(*token_program_id, false),
+        AccountMeta::new_readonly(*swap_guardian, true)
     ];
 
     Ok(Instruction {
@@ -452,6 +479,7 @@ pub fn deposit_single_token_type_exact_amount_in(
     pool_mint_pubkey: &Pubkey,
     destination_pubkey: &Pubkey,
     instruction: DepositSingleTokenTypeExactAmountIn,
+    swap_guardian: &Pubkey
 ) -> Result<Instruction, ProgramError> {
     let data = SwapInstruction::DepositSingleTokenTypeExactAmountIn(instruction).pack();
 
@@ -465,6 +493,7 @@ pub fn deposit_single_token_type_exact_amount_in(
         AccountMeta::new(*pool_mint_pubkey, false),
         AccountMeta::new(*destination_pubkey, false),
         AccountMeta::new_readonly(*token_program_id, false),
+        AccountMeta::new_readonly(*swap_guardian, true)
     ];
 
     Ok(Instruction {
@@ -488,6 +517,7 @@ pub fn withdraw_single_token_type_exact_amount_out(
     swap_token_b_pubkey: &Pubkey,
     destination_pubkey: &Pubkey,
     instruction: WithdrawSingleTokenTypeExactAmountOut,
+    swap_guardian: &Pubkey
 ) -> Result<Instruction, ProgramError> {
     let data = SwapInstruction::WithdrawSingleTokenTypeExactAmountOut(instruction).pack();
 
@@ -502,6 +532,7 @@ pub fn withdraw_single_token_type_exact_amount_out(
         AccountMeta::new(*destination_pubkey, false),
         AccountMeta::new(*fee_account_pubkey, false),
         AccountMeta::new_readonly(*token_program_id, false),
+        AccountMeta::new_readonly(*swap_guardian, true)
     ];
 
     Ok(Instruction {
@@ -526,6 +557,7 @@ pub fn swap(
     pool_fee_pubkey: &Pubkey,
     host_fee_pubkey: Option<&Pubkey>,
     instruction: Swap,
+    swap_guardian: &Pubkey
 ) -> Result<Instruction, ProgramError> {
     let data = SwapInstruction::Swap(instruction).pack();
 
@@ -540,6 +572,7 @@ pub fn swap(
         AccountMeta::new(*pool_mint_pubkey, false),
         AccountMeta::new(*pool_fee_pubkey, false),
         AccountMeta::new_readonly(*token_program_id, false),
+        AccountMeta::new_readonly(*swap_guardian, true),
     ];
     if let Some(host_fee_pubkey) = host_fee_pubkey {
         accounts.push(AccountMeta::new(*host_fee_pubkey, false));

--- a/token-swap/program/src/processor.rs
+++ b/token-swap/program/src/processor.rs
@@ -163,7 +163,7 @@ impl Processor {
         user_token_a_info: Option<&AccountInfo>,
         user_token_b_info: Option<&AccountInfo>,
         pool_fee_account_info: Option<&AccountInfo>,
-        swap_guardian_info: &AccountInfo
+        swap_guardian_info: &AccountInfo,
     ) -> ProgramResult {
         if swap_account_info.owner != program_id {
             return Err(ProgramError::IncorrectProgramId);
@@ -326,7 +326,7 @@ impl Processor {
             pool_fee_account: *fee_account_info.key,
             fees,
             swap_curve,
-            swap_guardian: *swap_guardian_info.key
+            swap_guardian: *swap_guardian_info.key,
         });
         SwapVersion::pack(obj, &mut swap_info.data.borrow_mut())?;
         Ok(())
@@ -546,7 +546,7 @@ impl Processor {
             Some(source_a_info),
             Some(source_b_info),
             None,
-            swap_guardian_info
+            swap_guardian_info,
         )?;
 
         let token_a = Self::unpack_token_account(token_a_info, token_swap.token_program_id())?;
@@ -651,7 +651,7 @@ impl Processor {
             Some(dest_token_a_info),
             Some(dest_token_b_info),
             Some(pool_fee_account_info),
-            swap_guardian_info
+            swap_guardian_info,
         )?;
 
         let token_a = Self::unpack_token_account(token_a_info, token_swap.token_program_id())?;
@@ -801,7 +801,7 @@ impl Processor {
             source_a_info,
             source_b_info,
             None,
-            swap_guardian_info
+            swap_guardian_info,
         )?;
 
         let pool_mint = Self::unpack_mint(pool_mint_info, token_swap.token_program_id())?;
@@ -919,7 +919,7 @@ impl Processor {
             destination_a_info,
             destination_b_info,
             Some(pool_fee_account_info),
-            swap_guardian_info
+            swap_guardian_info,
         )?;
 
         let pool_mint = Self::unpack_mint(pool_mint_info, token_swap.token_program_id())?;
@@ -1273,7 +1273,7 @@ mod tests {
         token_b_key: Pubkey,
         token_b_account: Account,
         token_b_mint_key: Pubkey,
-        token_b_mint_account: Account
+        token_b_mint_account: Account,
     }
 
     impl SwapAccountInfo {
@@ -1348,7 +1348,7 @@ mod tests {
                 token_b_key,
                 token_b_account,
                 token_b_mint_key,
-                token_b_mint_account
+                token_b_mint_account,
             }
         }
 
@@ -1366,7 +1366,7 @@ mod tests {
                     &self.pool_token_key,
                     self.fees.clone(),
                     self.swap_curve.clone(),
-                    &Pubkey::default()
+                    &Pubkey::default(),
                 )
                 .unwrap(),
                 vec![
@@ -1378,7 +1378,7 @@ mod tests {
                     &mut self.pool_fee_account,
                     &mut self.pool_token_account,
                     &mut Account::default(),
-                    &mut Account::default()
+                    &mut Account::default(),
                 ],
             )
         }
@@ -1500,7 +1500,7 @@ mod tests {
                         amount_in,
                         minimum_amount_out,
                     },
-                    &Pubkey::default()
+                    &Pubkey::default(),
                 )
                 .unwrap(),
                 vec![
@@ -1514,7 +1514,7 @@ mod tests {
                     &mut self.pool_mint_account,
                     &mut self.pool_fee_account,
                     &mut Account::default(),
-                    &mut Account::default()
+                    &mut Account::default(),
                 ],
             )?;
 
@@ -1593,7 +1593,7 @@ mod tests {
                         maximum_token_a_amount,
                         maximum_token_b_amount,
                     },
-                    &Pubkey::default()
+                    &Pubkey::default(),
                 )
                 .unwrap(),
                 vec![
@@ -1607,7 +1607,7 @@ mod tests {
                     &mut self.pool_mint_account,
                     depositor_pool_account,
                     &mut Account::default(),
-                    &mut Account::default()
+                    &mut Account::default(),
                 ],
             )
         }
@@ -1666,7 +1666,7 @@ mod tests {
                         minimum_token_a_amount,
                         minimum_token_b_amount,
                     },
-                    &Pubkey::default()
+                    &Pubkey::default(),
                 )
                 .unwrap(),
                 vec![
@@ -1681,7 +1681,7 @@ mod tests {
                     token_b_account,
                     &mut self.pool_fee_account,
                     &mut Account::default(),
-                    &mut Account::default()
+                    &mut Account::default(),
                 ],
             )
         }
@@ -1732,7 +1732,7 @@ mod tests {
                         source_token_amount,
                         minimum_pool_token_amount,
                     },
-                    &Pubkey::default()
+                    &Pubkey::default(),
                 )
                 .unwrap(),
                 vec![
@@ -1745,7 +1745,7 @@ mod tests {
                     &mut self.pool_mint_account,
                     deposit_pool_account,
                     &mut Account::default(),
-                    &mut Account::default()
+                    &mut Account::default(),
                 ],
             )
         }
@@ -1798,7 +1798,7 @@ mod tests {
                         destination_token_amount,
                         maximum_pool_token_amount,
                     },
-                    &Pubkey::default()
+                    &Pubkey::default(),
                 )
                 .unwrap(),
                 vec![
@@ -1812,7 +1812,7 @@ mod tests {
                     destination_account,
                     &mut self.pool_fee_account,
                     &mut Account::default(),
-                    &mut Account::default()
+                    &mut Account::default(),
                 ],
             )
         }
@@ -2474,7 +2474,7 @@ mod tests {
                         &mut accounts.pool_fee_account,
                         &mut accounts.pool_token_account,
                         &mut Account::default(),
-                        &mut Account::default() 
+                        &mut Account::default()
                     ],
                 )
             );
@@ -2791,7 +2791,7 @@ mod tests {
                     &accounts.pool_token_key,
                     accounts.fees,
                     accounts.swap_curve.clone(),
-                    &Pubkey::default()
+                    &Pubkey::default(),
                 )
                 .unwrap(),
                 vec![
@@ -2803,7 +2803,7 @@ mod tests {
                     &mut accounts.pool_fee_account,
                     &mut accounts.pool_token_account,
                     &mut Account::default(),
-                    &mut Account::default()
+                    &mut Account::default(),
                 ],
                 &constraints,
             )
@@ -5778,7 +5778,7 @@ mod tests {
                 &accounts.pool_token_key,
                 accounts.fees.clone(),
                 accounts.swap_curve.clone(),
-                &Pubkey::default()
+                &Pubkey::default(),
             )
             .unwrap(),
             vec![
@@ -5790,7 +5790,7 @@ mod tests {
                 &mut accounts.pool_fee_account,
                 &mut accounts.pool_token_account,
                 &mut Account::default(),
-                &mut Account::default()
+                &mut Account::default(),
             ],
             &constraints,
         )
@@ -5835,7 +5835,7 @@ mod tests {
                     amount_in,
                     minimum_amount_out,
                 },
-                &Pubkey::default()
+                &Pubkey::default(),
             )
             .unwrap(),
             vec![
@@ -6439,7 +6439,7 @@ mod tests {
                         amount_in: initial_a,
                         minimum_amount_out: minimum_token_b_amount,
                     },
-                    &Pubkey::default()
+                    &Pubkey::default(),
                 )
                 .unwrap(),
                 vec![
@@ -6453,7 +6453,7 @@ mod tests {
                     &mut accounts.pool_mint_account,
                     &mut accounts.pool_fee_account,
                     &mut Account::default(),
-                    &mut Account::default()
+                    &mut Account::default(),
                 ],
                 &constraints,
             )

--- a/token-swap/program/src/processor.rs
+++ b/token-swap/program/src/processor.rs
@@ -201,10 +201,10 @@ impl Processor {
             }
         }
         if *swap_guardian_info.key != *token_swap.swap_guardian() {
-            return Err(SwapError::WrongSwapGuardian.into());
+            return Err(SwapError::IncorrectSwapGuardian.into());
         }
         if !swap_guardian_info.is_signer {
-            return Err(SwapError::NoSwapGuardianSig.into());
+            return Err(SwapError::NoSwapGuardianSignature.into());
         }
         Ok(())
     }
@@ -391,10 +391,10 @@ impl Processor {
             return Err(SwapError::IncorrectTokenProgramId.into());
         }
         if *swap_guardian_info.key != *token_swap.swap_guardian() {
-            return Err(SwapError::WrongSwapGuardian.into());
+            return Err(SwapError::IncorrectSwapGuardian.into());
         }
         if !swap_guardian_info.is_signer {
-            return Err(SwapError::NoSwapGuardianSig.into());
+            return Err(SwapError::NoSwapGuardianSignature.into());
         }
 
         let source_account =
@@ -1157,10 +1157,10 @@ impl PrintProgramError for SwapError {
             SwapError::UnsupportedCurveOperation => {
                 msg!("Error: The operation cannot be performed on the given curve")
             }
-            SwapError::WrongSwapGuardian => {
+            SwapError::IncorrectSwapGuardian => {
                 msg!("Error: The provided swap guardian is incorrect")
             }
-            SwapError::NoSwapGuardianSig => {
+            SwapError::NoSwapGuardianSignature => {
                 msg!("Error: No swap guardian signature")
             }
         }

--- a/token-swap/program/src/state.rs
+++ b/token-swap/program/src/state.rs
@@ -38,6 +38,8 @@ pub trait SwapState {
     fn fees(&self) -> &Fees;
     /// Curve associated with swap
     fn swap_curve(&self) -> &SwapCurve;
+    /// Guardian for the swap.
+    fn swap_guardian(&self) -> &Pubkey;
 }
 
 /// All versions of SwapState
@@ -125,6 +127,9 @@ pub struct SwapV1 {
     /// Swap curve parameters, to be unpacked and used by the SwapCurve, which
     /// calculates swaps, deposits, and withdrawals
     pub swap_curve: SwapCurve,
+
+    /// Gates interactions with the swap.
+    pub swap_guardian: Pubkey
 }
 
 impl SwapState for SwapV1 {
@@ -171,6 +176,10 @@ impl SwapState for SwapV1 {
     fn swap_curve(&self) -> &SwapCurve {
         &self.swap_curve
     }
+
+    fn swap_guardian(&self) -> &Pubkey {
+        &self.swap_guardian
+    }
 }
 
 impl Sealed for SwapV1 {}
@@ -181,10 +190,10 @@ impl IsInitialized for SwapV1 {
 }
 
 impl Pack for SwapV1 {
-    const LEN: usize = 323;
+    const LEN: usize = 355;
 
     fn pack_into_slice(&self, output: &mut [u8]) {
-        let output = array_mut_ref![output, 0, 323];
+        let output = array_mut_ref![output, 0, 355];
         let (
             is_initialized,
             bump_seed,
@@ -197,7 +206,8 @@ impl Pack for SwapV1 {
             pool_fee_account,
             fees,
             swap_curve,
-        ) = mut_array_refs![output, 1, 1, 32, 32, 32, 32, 32, 32, 32, 64, 33];
+            swap_guardian
+        ) = mut_array_refs![output, 1, 1, 32, 32, 32, 32, 32, 32, 32, 64, 33, 32];
         is_initialized[0] = self.is_initialized as u8;
         bump_seed[0] = self.bump_seed;
         token_program_id.copy_from_slice(self.token_program_id.as_ref());
@@ -209,11 +219,12 @@ impl Pack for SwapV1 {
         pool_fee_account.copy_from_slice(self.pool_fee_account.as_ref());
         self.fees.pack_into_slice(&mut fees[..]);
         self.swap_curve.pack_into_slice(&mut swap_curve[..]);
+        swap_guardian.copy_from_slice(self.swap_guardian.as_ref());
     }
 
     /// Unpacks a byte buffer into a [SwapV1](struct.SwapV1.html).
     fn unpack_from_slice(input: &[u8]) -> Result<Self, ProgramError> {
-        let input = array_ref![input, 0, 323];
+        let input = array_ref![input, 0, 355];
         #[allow(clippy::ptr_offset_with_cast)]
         let (
             is_initialized,
@@ -227,7 +238,8 @@ impl Pack for SwapV1 {
             pool_fee_account,
             fees,
             swap_curve,
-        ) = array_refs![input, 1, 1, 32, 32, 32, 32, 32, 32, 32, 64, 33];
+            swap_guardian
+        ) = array_refs![input, 1, 1, 32, 32, 32, 32, 32, 32, 32, 64, 33, 32];
         Ok(Self {
             is_initialized: match is_initialized {
                 [0] => false,
@@ -244,6 +256,7 @@ impl Pack for SwapV1 {
             pool_fee_account: Pubkey::new_from_array(*pool_fee_account),
             fees: Fees::unpack_from_slice(fees)?,
             swap_curve: SwapCurve::unpack_from_slice(swap_curve)?,
+            swap_guardian: Pubkey::new_from_array(*swap_guardian)
         })
     }
 }
@@ -274,6 +287,7 @@ mod tests {
     const TEST_TOKEN_A_MINT: Pubkey = Pubkey::new_from_array([5u8; 32]);
     const TEST_TOKEN_B_MINT: Pubkey = Pubkey::new_from_array([6u8; 32]);
     const TEST_POOL_FEE_ACCOUNT: Pubkey = Pubkey::new_from_array([7u8; 32]);
+    const TEST_SWAP_GUARDIAN: Pubkey = Pubkey::new_from_array([8u8; 32]);
 
     const TEST_CURVE_TYPE: u8 = 2;
     const TEST_AMP: u64 = 1;
@@ -299,6 +313,7 @@ mod tests {
             pool_fee_account: TEST_POOL_FEE_ACCOUNT,
             fees: TEST_FEES,
             swap_curve: swap_curve.clone(),
+            swap_guardian: TEST_SWAP_GUARDIAN
         });
 
         let mut packed = [0u8; SwapVersion::LATEST_LEN];
@@ -316,6 +331,7 @@ mod tests {
         assert_eq!(*unpacked.pool_fee_account(), TEST_POOL_FEE_ACCOUNT);
         assert_eq!(*unpacked.fees(), TEST_FEES);
         assert_eq!(*unpacked.swap_curve(), swap_curve);
+        assert_eq!(*unpacked.swap_guardian(), TEST_SWAP_GUARDIAN);
     }
 
     #[test]
@@ -338,6 +354,7 @@ mod tests {
             pool_fee_account: TEST_POOL_FEE_ACCOUNT,
             fees: TEST_FEES,
             swap_curve,
+            swap_guardian: TEST_SWAP_GUARDIAN
         };
 
         let mut packed = [0u8; SwapV1::LEN];
@@ -364,6 +381,7 @@ mod tests {
         packed.push(TEST_CURVE_TYPE);
         packed.extend_from_slice(&TEST_AMP.to_le_bytes());
         packed.extend_from_slice(&[0u8; 24]);
+        packed.extend_from_slice(&TEST_SWAP_GUARDIAN.to_bytes());
         let unpacked = SwapV1::unpack(&packed).unwrap();
         assert_eq!(swap_info, unpacked);
 

--- a/token-swap/program/src/state.rs
+++ b/token-swap/program/src/state.rs
@@ -129,7 +129,7 @@ pub struct SwapV1 {
     pub swap_curve: SwapCurve,
 
     /// Gates interactions with the swap.
-    pub swap_guardian: Pubkey
+    pub swap_guardian: Pubkey,
 }
 
 impl SwapState for SwapV1 {
@@ -206,7 +206,7 @@ impl Pack for SwapV1 {
             pool_fee_account,
             fees,
             swap_curve,
-            swap_guardian
+            swap_guardian,
         ) = mut_array_refs![output, 1, 1, 32, 32, 32, 32, 32, 32, 32, 64, 33, 32];
         is_initialized[0] = self.is_initialized as u8;
         bump_seed[0] = self.bump_seed;
@@ -238,7 +238,7 @@ impl Pack for SwapV1 {
             pool_fee_account,
             fees,
             swap_curve,
-            swap_guardian
+            swap_guardian,
         ) = array_refs![input, 1, 1, 32, 32, 32, 32, 32, 32, 32, 64, 33, 32];
         Ok(Self {
             is_initialized: match is_initialized {
@@ -256,7 +256,7 @@ impl Pack for SwapV1 {
             pool_fee_account: Pubkey::new_from_array(*pool_fee_account),
             fees: Fees::unpack_from_slice(fees)?,
             swap_curve: SwapCurve::unpack_from_slice(swap_curve)?,
-            swap_guardian: Pubkey::new_from_array(*swap_guardian)
+            swap_guardian: Pubkey::new_from_array(*swap_guardian),
         })
     }
 }
@@ -313,7 +313,7 @@ mod tests {
             pool_fee_account: TEST_POOL_FEE_ACCOUNT,
             fees: TEST_FEES,
             swap_curve: swap_curve.clone(),
-            swap_guardian: TEST_SWAP_GUARDIAN
+            swap_guardian: TEST_SWAP_GUARDIAN,
         });
 
         let mut packed = [0u8; SwapVersion::LATEST_LEN];
@@ -354,7 +354,7 @@ mod tests {
             pool_fee_account: TEST_POOL_FEE_ACCOUNT,
             fees: TEST_FEES,
             swap_curve,
-            swap_guardian: TEST_SWAP_GUARDIAN
+            swap_guardian: TEST_SWAP_GUARDIAN,
         };
 
         let mut packed = [0u8; SwapV1::LEN];


### PR DESCRIPTION
This PR handles [this ticket](https://app.asana.com/0/1199953095960779/1201760072593316/f).

- Changes swap fees to 0.
- Adds a guardian account as signer. Swap actions cannot be taken without this account's signature. This allows us to gate swaps based on additional logic (e.g. prevent swaps past market expiry time).